### PR TITLE
Fixed warning 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "typer[all]",
     "transformers[torch]",
     "scikit-image",
-    "diffusers[StableDiffusionPipeline]"
+    "diffusers"
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixed warning: diffusers 0.24.0 does not provide extra 'stablediffusionpipeline'

closes #38 