### PR TITLE
Add initial Jupyter Notebook

### DIFF
--- a/Main.ipynb
+++ b/Main.ipynb
@@ -26,21 +26,12 @@
       }
     },
     {
-      "cell_type": "markdown",
-      "source": [
-        "##Note: This Notebook does currently only run on the fallback runtime of Google Colab. Please enable it as described here: https://github.com/googlecolab/colabtools/issues/4214"
-      ],
-      "metadata": {
-        "id": "lfDeiHXr9pVA"
-      }
-    },
-    {
       "cell_type": "code",
       "source": [
         "# Uncomment and run this cell if you're on Colab. Make sure to replace {USERNAME} and {TOKEN} with your username and a personal access token\n",
         "# !git clone https://{USERNAME}:{TOKEN}@github.com/Ctrl-Alt-Defeat-Foundation-Models/informatiCup2024.git\n",
         "# !pip install -e ./informatiCup2024/\n",
-        "# !pip install https://download.pytorch.org/whl/cu118/torch-2.1.0%2Bcu118-cp310-cp310-linux_x86_64.whl"
+        "# !pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cu118"
       ],
       "metadata": {
         "id": "SkkJNGMD20uz"


### PR DESCRIPTION
This PR adds an initial version for a Jupyter Notebook. It does currently only work for the fallback version of Google Colab, which is only available until the beginning of January, so as a follow up, we should check to make it compatible with the current normal version. However, this involves some shenanigans with torch and CUDA versions, so I decided to submit first this version and update it later if possible. Please check if you are able to use it, or if you need further instructions added somewhere.